### PR TITLE
Removed autofocus from chat textarea

### DIFF
--- a/src/components/chat.tsx
+++ b/src/components/chat.tsx
@@ -535,9 +535,10 @@ export default function Chat({
     if (entryMessage && messages.length === 0) {
       addMessage(entryMessage);
     }
-    if (textarea) {
-      textarea.focus(); // Automatically focus the textarea
-    }
+    // Removed autofocus per new requirements
+    // if (textarea) {
+    //   textarea.focus(); // Automatically focus the textarea
+    // }
   }, []);
 
   if (errorMessage) {


### PR DESCRIPTION
Autofocus was causing issues on the Results page as well as mobile version of the participant chat. As a quick fix I've removed autofocus from all instances of this component.