### PR TITLE
Export Responses Fix

### DIFF
--- a/src/components/Export/ExportSection.tsx
+++ b/src/components/Export/ExportSection.tsx
@@ -4,7 +4,7 @@ import {
   analyzeWithSimScore,
   extractDataFromUserMessages,
 } from 'app/api/exportUtils';
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import { Label } from '@/components/ui/label';
 import { Textarea } from '@/components/ui/textarea';
 import { Spinner } from '../icons';
@@ -12,6 +12,12 @@ import { Button } from '../ui/button';
 import { usePermissions } from '@/lib/permissions';
 import { useCustomResponses } from '../SessionResult/ResultTabs/hooks/useCustomResponses';
 import { OpenAIMessage } from '@/lib/types';
+import { X, Download } from 'lucide-react';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
+import { Card, CardContent, CardFooter, CardHeader, CardTitle } from '@/components/ui/card';
+import { Checkbox } from '@/components/ui/checkbox';
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table';
+import { Badge } from '@/components/ui/badge';
 
 // ExportSection.tsx
 export default function ExportSection({
@@ -19,41 +25,73 @@ export default function ExportSection({
   userData,
   id,
   className,
+  isOpen,
+  onOpenChange,
 }: {
   hostData: HostSession;
   userData: UserSession[];
   id: string;
   className?: string;
+  isOpen?: boolean;
+  onOpenChange?: (open: boolean) => void;
 }) {
   const { addResponse } = useCustomResponses(id);
   const [exportInProgress, setExportInProgress] = useState(false);
   const [isExportPopupVisible, setIsExportPopupVisible] = useState(false);
-  const [exportInstructions, setExportInstructions] = useState('');
+  
+  // Use external control if provided, otherwise use internal state
+  const modalVisible = isOpen !== undefined ? isOpen : isExportPopupVisible;
+  const setModalVisible = onOpenChange || setIsExportPopupVisible;
+  const [onlyIncluded, setOnlyIncluded] = useState(true);
+  const [onlyFinished, setOnlyFinished] = useState(true);
+  const [noResultsWarning, setNoResultsWarning] = useState(false);
+  const [selectedParticipants, setSelectedParticipants] = useState<Set<string>>(new Set());
+  const [includeSessionDetails, setIncludeSessionDetails] = useState(true);
+
+  // Initialize selected participants to match include_in_summary when modal opens
+  useEffect(() => {
+    if (modalVisible) {
+      const includedParticipants = userData
+        .filter(u => u.include_in_summary)
+        .map(u => u.id);
+      setSelectedParticipants(new Set(includedParticipants));
+    }
+  }, [modalVisible]);
+
+  // Handle escape key to close modal
+  useEffect(() => {
+    const handleEscape = (event: KeyboardEvent) => {
+      if (event.key === 'Escape' && modalVisible) {
+        setModalVisible(false);
+      }
+    };
+
+    if (modalVisible) {
+      document.addEventListener('keydown', handleEscape);
+    }
+
+    return () => {
+      document.removeEventListener('keydown', handleEscape);
+    };
+  }, [modalVisible, setModalVisible]);
 
   const exportSessionResults = async (e: React.FormEvent) => {
     e.preventDefault();
-    setIsExportPopupVisible(true);
     setExportInProgress(true);
+    setNoResultsWarning(false);
 
-    const response = await extractDataFromUserMessages(
-      userData,
-      exportInstructions,
-    );
+    let filteredUserData = userData;
+    if (selectedParticipants.size > 0) {
+      filteredUserData = filteredUserData.filter(u => selectedParticipants.has(u.id));
+    }
+    if (filteredUserData.length === 0) {
+      setNoResultsWarning(true);
+      setExportInProgress(false);
+      return;
+    }
 
-    const blob = new Blob([JSON.stringify(JSON.parse(response), null, 2)], {
-      type: 'application/json',
-    });
-    const link = document.createElement('a');
-    exportAndDownload(blob, link, `Harmonica_${hostData.topic ?? id}.json`);
-
-    setExportInProgress(false);
-    setIsExportPopupVisible(false);
-  };
-
-  const exportAllData = async () => {
-    const allMessages = await db.getAllMessagesForUsersSorted(userData);
-    const exportData = userData.map((user) => {
-      const user_id = user.user_id;
+    const allMessages = await db.getAllMessagesForUsersSorted(filteredUserData);
+    const exportData = filteredUserData.map((user) => {
       const user_name = user.user_name;
       const introString = `Use it in communication. Don't ask it again. Start the session.\n`;
       const messagesForOneUser = allMessages.filter(
@@ -65,28 +103,108 @@ export default function ExportSection({
       }
       const chat_text = concatenateMessages(messagesForOneUser);
       return {
-        user_id,
         user_name,
         chat_text,
       };
     });
+
+    // Add session details if checkbox is checked
+    const finalExportData = includeSessionDetails ? {
+      session_details: {
+        topic: hostData.topic,
+        goal: hostData.goal,
+        critical: hostData.critical,
+        context: hostData.context,
+        start_time: hostData.start_time,
+        last_edit: hostData.last_edit,
+      },
+      participants: exportData
+    } : exportData;
+
     exportAndDownload(
-      new Blob([JSON.stringify(exportData, null, 2)], {
+      new Blob([JSON.stringify(finalExportData, null, 2)], {
         type: 'application/json',
       }),
       document.createElement('a'),
-      `Harmonica_${hostData.topic ?? id}_allData.json`,
+      `Harmonica_${hostData.topic ?? id}_${new Date().toISOString().slice(0, 19).replace(/:/g, '-')}.json`,
     );
     setExportInProgress(false);
-    setIsExportPopupVisible(false);
+    setModalVisible(false);
+  };
+
+  const exportAllData = async () => {
+    const allMessages = await db.getAllMessagesForUsersSorted(userData);
+    const exportData = userData.map((user) => {
+      const user_name = user.user_name;
+      const introString = `Use it in communication. Don't ask it again. Start the session.\n`;
+      const messagesForOneUser = allMessages.filter(
+        (msg) => msg.thread_id === user.thread_id,
+      );
+      if (messagesForOneUser.length === 0) return;
+      if (messagesForOneUser[0].content.includes(introString)) {
+        messagesForOneUser.shift();
+      }
+      const chat_text = concatenateMessages(messagesForOneUser);
+      return {
+        user_name,
+        chat_text,
+      };
+    });
+
+    // Add session details if checkbox is checked
+    const finalExportData = includeSessionDetails ? {
+      session_details: {
+        topic: hostData.topic,
+        goal: hostData.goal,
+        critical: hostData.critical,
+        context: hostData.context,
+        start_time: hostData.start_time,
+        last_edit: hostData.last_edit,
+      },
+      participants: exportData
+    } : exportData;
+
+    exportAndDownload(
+      new Blob([JSON.stringify(finalExportData, null, 2)], {
+        type: 'application/json',
+      }),
+      document.createElement('a'),
+      `Harmonica_${hostData.topic ?? id}_${new Date().toISOString().slice(0, 19).replace(/:/g, '-')}.json`,
+    );
+    setExportInProgress(false);
+    setModalVisible(false);
   };
 
   const handleShowExportPopup = () => {
-    setIsExportPopupVisible(true);
+    setModalVisible(true);
   };
 
   const handleCloseExportPopup = () => {
-    setIsExportPopupVisible(false);
+    setModalVisible(false);
+  };
+
+  const handleSelectAll = () => {
+    if (selectedParticipants.size === userData.length) {
+      setSelectedParticipants(new Set());
+    } else {
+      setSelectedParticipants(new Set(userData.map(u => u.id)));
+    }
+  };
+
+  const handleSelectAllClick = (e: React.MouseEvent) => {
+    e.preventDefault();
+    e.stopPropagation();
+    handleSelectAll();
+  };
+
+  const handleSelectParticipant = (participantId: string) => {
+    const newSelected = new Set(selectedParticipants);
+    if (newSelected.has(participantId)) {
+      newSelected.delete(participantId);
+    } else {
+      newSelected.add(participantId);
+    }
+    setSelectedParticipants(newSelected);
   };
 
   function concatenateMessages(messagesFromOneUser: Message[]) {
@@ -112,43 +230,6 @@ export default function ExportSection({
     document.body.removeChild(link);
   }
 
-  const rankWithSimScore = async () => {
-    setIsExportPopupVisible(true);
-    setExportInProgress(true);
-    const sampleObject = [{ author_id: 'user_name', idea: 'idea1' }];
-    const adjustedExportInstructions = `${exportInstructions}
-\n!IMPORTANT! Use the following JSON schema. 
-If specified, group different subject areas and their ideas together.\n
-\`\`\`json\n 
-${JSON.stringify(sampleObject, null, 2)};
-\`\`\`\n
-ONLY include plain JSON in your reply, without any backticks, markdown formatting, or explanations!`;
-    const extractedData = await extractDataFromUserMessages(
-      userData,
-      adjustedExportInstructions,
-    );
-    console.log('Extracted Data: ', extractedData);
-    const analyzed = await analyzeWithSimScore(extractedData).catch((error) =>
-      console.log('Sorry, there was an error! ', error),
-    );
-    console.log('Simscore-analyzed data: ', analyzed);
-
-    if (analyzed) {
-      // Format the SimScore results as an OpenAIMessage
-      const simScoreMessage: OpenAIMessage = {
-        role: 'assistant',
-        content: `## SimScore Analysis Results\n\n${analyzed}`,
-      };
-
-      // Add to Custom Insights using the hook
-      addResponse(simScoreMessage);
-    }
-
-    setExportInProgress(false);
-    setIsExportPopupVisible(false);
-    return analyzed;
-  };
-
   const { hasMinimumRole, loading } = usePermissions(id);
 
   return (
@@ -156,53 +237,128 @@ ONLY include plain JSON in your reply, without any backticks, markdown formattin
       <Button className={className} onClick={handleShowExportPopup}>
         Export Session Details
       </Button>
-      {isExportPopupVisible && (
-        <div className="fixed inset-0 bg-black bg-opacity-75 flex items-center justify-center z-50">
-          <div className="bg-purple-100 border-purple-200 p-8 rounded-lg w-4/5 md:w-3/5 lg:w-1/2 flex flex-col">
-            <div className="flex justify-between mb-4">
-              <h2 className="text-2xl font-bold">JSON Export</h2>
-              <Button onClick={handleCloseExportPopup} variant="ghost">
-                X
-              </Button>
-            </div>
-
-            <div className="flex-1 overflow-auto rounded-lg">
-              <div className="space-y-2">
-                <form
-                  className="bg-white mx-auto p-10 rounded-xl shadow space-y-4"
-                  onSubmit={exportSessionResults}
-                >
-                  <Label htmlFor="export" size="lg">
-                    What would you like to export?
-                  </Label>
-                  <Textarea
-                    name="export"
-                    onChange={(e) => setExportInstructions(e.target.value)}
-                    placeholder="Export 'names' of participants and their 'opinions'"
-                    required
-                  />
-                  <p className="text-sm text-muted-foreground">
-                    Enter some human-readable instructions, or a JSON scheme.
-                  </p>
-                  {exportInProgress ? (
-                    <>
-                      <Spinner />
-                      Exporting...
-                    </>
-                  ) : (
-                    <div className="flex justify-between items-center">
-                      <Button type="submit">Submit</Button>
-                      {!loading && hasMinimumRole('owner') && (
-                        <Button onClick={exportAllData} variant="ghost">
-                          {' Export All '}
+      {modalVisible && (
+        <div className="fixed inset-0 bg-black bg-opacity-75 flex items-center justify-center z-50 p-4">
+          <Card className="w-full max-w-xl">
+            <CardHeader>
+              <CardTitle>Export Results</CardTitle>
+              <p className="text-sm text-muted-foreground mt-1">
+                Export participant transcripts
+              </p>
+            </CardHeader>
+            <CardContent>
+              <form onSubmit={exportSessionResults}>
+                <div className="flex flex-col gap-4">
+                  <div className="space-y-3">
+                    <div className="flex items-center justify-between">
+                      <Label className="text-sm font-medium">Select participants to export</Label>
+                      <div className="flex items-center gap-2">
+                        <span className="text-sm text-muted-foreground">
+                          {selectedParticipants.size} selected
+                        </span>
+                        <Button
+                          variant="outline"
+                          size="sm"
+                          onClick={handleSelectAllClick}
+                        >
+                          {selectedParticipants.size === userData.length ? 'Deselect all' : 'Select all'}
                         </Button>
-                      )}
+                      </div>
+                    </div>
+                    <div className="border rounded-lg max-h-64 overflow-auto">
+                      <Table>
+                        <TableHeader>
+                          <TableRow>
+                            <TableHead className="w-12">
+                              <div className="flex items-center">
+                                <Checkbox
+                                  checked={selectedParticipants.size === userData.length && userData.length > 0}
+                                  onCheckedChange={handleSelectAll}
+                                />
+                              </div>
+                            </TableHead>
+                            <TableHead>Name</TableHead>
+                            <TableHead>Status</TableHead>
+                          </TableRow>
+                        </TableHeader>
+                        <TableBody>
+                          {userData
+                            .sort((a, b) => new Date(b.last_edit).getTime() - new Date(a.last_edit).getTime())
+                            .map((participant) => (
+                              <TableRow key={participant.id}>
+                                <TableCell>
+                                  <Checkbox
+                                    checked={selectedParticipants.has(participant.id)}
+                                    onCheckedChange={() => handleSelectParticipant(participant.id)}
+                                  />
+                                </TableCell>
+                                <TableCell className="font-medium">
+                                  {participant.user_name || 'Anonymous'}
+                                </TableCell>
+                                <TableCell>
+                                  <Badge
+                                    variant="outline"
+                                    className={
+                                      participant.active ? 'capitalize' : 'capitalize bg-[#ECFCCB]'
+                                    }
+                                  >
+                                    {participant.active ? 'Started' : 'Finished'}
+                                  </Badge>
+                                </TableCell>
+                              </TableRow>
+                            ))}
+                          </TableBody>
+                      </Table>
+                    </div>
+                  </div>
+                  <Card className="p-4">
+                    <div className="flex items-start space-x-3">
+                      <Checkbox
+                        id="include-session-details"
+                        checked={includeSessionDetails}
+                        onCheckedChange={(checked) => setIncludeSessionDetails(checked as boolean)}
+                        className="mt-0.5"
+                      />
+                      <div className="space-y-1">
+                        <Label htmlFor="include-session-details" className="text-sm font-medium">
+                          Include Session Metadata
+                        </Label>
+                        <p className="text-sm text-muted-foreground">
+                          Session details and context included in export
+                        </p>
+                      </div>
+                    </div>
+                  </Card>
+                  {noResultsWarning && (
+                    <div className="text-red-600 text-sm">
+                      No responses match your filters.
                     </div>
                   )}
-                </form>
-              </div>
-            </div>
-          </div>
+                </div>
+              </form>
+            </CardContent>
+                                      <CardFooter className="flex justify-between">
+                            <Button onClick={handleCloseExportPopup} variant="outline">
+                              Back
+                            </Button>
+                                          <div className="flex items-center gap-4">
+                              <span className="text-sm text-muted-foreground">
+                                Format: JSON
+                              </span>
+                              {exportInProgress ? (
+                                <div className="flex items-center gap-2">
+                                  <Spinner />
+                                  Downloading...
+                                </div>
+                              ) : (
+                                <Button onClick={exportSessionResults}>
+                                  <Download className="w-4 h-4 mr-2" />
+                                  Download
+                                </Button>
+                              )}
+                            </div>
+            </CardFooter>
+          </Card>
         </div>
       )}
     </>

--- a/src/components/SessionResult/ResultTabs/index.tsx
+++ b/src/components/SessionResult/ResultTabs/index.tsx
@@ -199,6 +199,7 @@ export default function ResultTabs({
           <SessionParticipantsTable
             sessionId={resourceId}
             userData={currentUserData}
+            hostData={hostData[0]}
             onIncludeInSummaryChange={updateIncludedInAnalysisList}
           />
         ),

--- a/src/components/SessionResult/SessionParticipantsTable.tsx
+++ b/src/components/SessionResult/SessionParticipantsTable.tsx
@@ -8,10 +8,12 @@ import {
 } from '@/components/ui/card';
 import ParticipantSessionRow from './ParticipantSessionRow';
 import SortableTable, { TableHeaderData } from '../SortableTable';
-import { UserSession } from '@/lib/schema';
+import { UserSession, HostSession } from '@/lib/schema';
 import { Button } from '@/components/ui/button';
 import GenerateResponsesModal from './GenerateResponsesModal';
 import ImportResponsesModal from './ImportResponsesModal';
+import { Download, Sparkles } from 'lucide-react';
+import ExportSection from '../Export/ExportSection';
 
 export type ParticipantsTableData = {
   userName: string;
@@ -25,14 +27,17 @@ export type ParticipantsTableData = {
 export default function SessionParticipantsTable({
   sessionId,
   userData,
+  hostData,
   onIncludeInSummaryChange,
 }: {
   sessionId: string;
   userData: UserSession[];
+  hostData: HostSession;
   onIncludeInSummaryChange: (userId: string, included: boolean) => void;
 }) {
   const [isGenerateModalOpen, setIsGenerateModalOpen] = useState(false);
   const [isImportModalOpen, setIsImportModalOpen] = useState(false);
+  const [isExportModalOpen, setIsExportModalOpen] = useState(false);
 
   const dateSorter = (sortDirection: string, a: string, b: string) => {
     return sortDirection === 'asc'
@@ -93,10 +98,20 @@ export default function SessionParticipantsTable({
             </CardDescription>
           </div>
           <div className="flex gap-2">
+            {userData.length > 0 && (
+                          <Button
+              variant="ghost"
+              onClick={() => setIsExportModalOpen(true)}
+            >
+              <Download className="w-4 h-4" />
+              Export
+            </Button>
+            )}
             <Button
-              variant="default"
+              variant="outline"
               onClick={() => setIsGenerateModalOpen(true)}
             >
+              <Sparkles className="w-4 h-4" />
               Generate Responses
             </Button>
           </div>
@@ -126,6 +141,16 @@ export default function SessionParticipantsTable({
           sessionId={sessionId}
         />
       </Card>
+      
+      {/* Export Modal */}
+      <ExportSection
+        hostData={hostData}
+        userData={userData}
+        id={sessionId}
+        className="hidden"
+        isOpen={isExportModalOpen}
+        onOpenChange={setIsExportModalOpen}
+      />
     </>
   );
 }

--- a/src/components/SessionResult/SessionResultsSection.tsx
+++ b/src/components/SessionResult/SessionResultsSection.tsx
@@ -8,7 +8,7 @@ import { checkSummaryAndMessageTimes } from '@/lib/clientUtils';
 import { SummaryUpdateManager } from '../../summary/SummaryUpdateManager';
 
 import ResultTabs from './ResultTabs';
-import ExportSection from '../Export/ExportSection';
+
 import { OpenAIMessage } from '@/lib/types';
 import { ResultTabsVisibilityConfig } from '@/lib/schema';
 import { usePermissions } from '@/lib/permissions';
@@ -57,14 +57,7 @@ export default function SessionResultsSection({
             visibilityConfig={visibilityConfig}
             chatEntryMessage={chatEntryMessage}
           />
-          {visibilityConfig.showResponses && hasMinimumRole('editor') && hasMessages && (
-            <ExportSection
-              hostData={hostData}
-              userData={userData}
-              id={resourceId}
-              className="mt-4"
-            />
-          )}
+
     </>
   );
 }


### PR DESCRIPTION
### What does this PR do?
Improves the export functionality for session hosts with a more intuitive and precise export flow. Key changes include relocating the export button from the bottom of the Results page to within the Responses tab (where it's contextually relevant), replacing the generic AI-powered export field with a manual participant selection interface, and adding an option to include or exclude session metadata in exports.

### Motivation
The previous export experience had several critical issues for session hosts:
- The export button was hard to find/easy to miss at the bottom of the Results page, and wasn't positioned with contextually relevant functionality
- The open AI-powered text field made it unclear what 'available fields' were or what *could* be exported
- You couldn't export a selection of chats easily, which meant test inputs and incomplete sessions would be included in exports. This had a huge impact on processing results easily in another LLM, which we experienced firsthand on a recent Enterprise tier project where we were the users on behalf of the customer.

The new approach gives hosts explicit control over exactly which participants and data to include in their exports, positioned where they're already reviewing participant responses.

### Testing Guidelines
Tested the improved export flow with:
- Export button placement and accessibility within the Responses tab
- Manual participant selection (individual checkboxes vs select all)
- Session metadata inclusion toggle functionality  
- Export format consistency (JSON) with selected participants only
- Edge cases like exporting with no participants selected or mixed participant statuses (Started vs Finished)

### Additional Notes
This change makes the export feature more predictable and user-friendly by removing AI interpretation from the selection process. Session hosts now have full visibility and control over what gets exported, enabling cleaner data processing workflows for analysis and integration with other tools/LLMs.

### Types of Changes
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply
- [x] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Harmonica