### PR TITLE
Set default crossPollination to false in creation flow

### DIFF
--- a/src/app/create/create.tsx
+++ b/src/app/create/create.tsx
@@ -39,7 +39,7 @@ export default function CreateSession({
 
   useEffect(() => {
     if (formData.crossPollination === undefined) {
-      onFormDataChange({ crossPollination: true });
+      onFormDataChange({ crossPollination: false });
     }
   }, []);
 

--- a/src/app/create/creationFlow.tsx
+++ b/src/app/create/creationFlow.tsx
@@ -105,7 +105,7 @@ export default function CreationFlow() {
     goal: '',
     critical: '',
     context: '',
-    crossPollination: true,
+    crossPollination: false,
   });
 
   const [templateId, setTemplateId] = useState<string | undefined>();


### PR DESCRIPTION
Changed the initial value of crossPollination from true to false in both CreateSession and CreationFlow components to update the default behavior.