### PR TITLE
Add Fallback for LLM overload errors

### DIFF
--- a/src/app/create/creationFlow.tsx
+++ b/src/app/create/creationFlow.tsx
@@ -203,6 +203,12 @@ export default function CreationFlow() {
     e.preventDefault();
     setIsLoading(true);
     const currentPrompt = prompts[currentVersion - 1];
+    
+    if (!currentPrompt || !currentPrompt.fullPrompt) {
+      setIsLoading(false);
+      throw new Error('No prompt available. Please create a prompt first.');
+    }
+    
     const prompt = currentPrompt.fullPrompt;
     const promptSummary = currentPrompt.summary;
 

--- a/src/lib/clientUtils.ts
+++ b/src/lib/clientUtils.ts
@@ -19,12 +19,23 @@ export const sendApiCall = async (request: RequestData) => {
     body: JSON.stringify(request),
   }).catch((error) => {
     console.error('Error sending or receiving API call:', error);
-    return error;
+    throw new Error(`Network error: ${error.message}`);
   });
 
   if (!response.ok) {
     console.error('Error from API:', response.status, response.statusText);
-    return null;
+    let errorMessage = `API error: ${response.status} ${response.statusText}`;
+    
+    try {
+      const errorData = await response.json();
+      if (errorData.error) {
+        errorMessage = errorData.error;
+      }
+    } catch (e) {
+      // If we can't parse the error response, use the default message
+    }
+    
+    throw new Error(errorMessage);
   }
 
   if (request.stream) {


### PR DESCRIPTION
Introduces a fallback to when the primary LLM (Anthropic/Claude) is overloaded in both finishedResponse and streamResponse functions. Also improves error handling in sendApiCall by throwing errors instead of returning them, and adds prompt validation in creationFlow to prevent empty prompt submissions.

Test
1. go through create session flow (submit anything)
2. wait on loading screen (may take a couple mins)
3. view summarised prompt on 'refine step'

If all above complete ok then it's in working order