### PR TITLE
feat(api): add distribution and cross_pollination to PATCH /sessions/:id (HAR-502)

### DIFF
--- a/src/app/api/v1/sessions/[id]/route.ts
+++ b/src/app/api/v1/sessions/[id]/route.ts
@@ -48,6 +48,8 @@ const ALLOWED_UPDATE_FIELDS: (keyof UpdateSessionRequest)[] = [
   'context',
   'critical',
   'prompt',
+  'cross_pollination',
+  'distribution',
 ];
 
 export async function PATCH(
@@ -76,6 +78,11 @@ export async function PATCH(
     // Keep prompt_summary in sync when prompt changes
     if (typeof update.prompt === 'string') {
       update.prompt_summary = update.prompt.substring(0, 500);
+    }
+
+    // Serialize distribution array to JSON string for storage
+    if (update.distribution !== undefined) {
+      update.distribution = update.distribution ? JSON.stringify(update.distribution) : null;
     }
 
     if (Object.keys(update).length === 0) {

--- a/src/lib/api-types.ts
+++ b/src/lib/api-types.ts
@@ -47,6 +47,8 @@ export interface UpdateSessionRequest {
   context?: string;
   critical?: string;
   prompt?: string;
+  cross_pollination?: boolean;
+  distribution?: DistributionTarget[];
 }
 
 export interface SessionCreated extends SessionListItem {


### PR DESCRIPTION
## Summary

Port of harmonicabot/harmonica-web-app-pro#42. Adds `distribution` and `cross_pollination` to the PATCH `/api/v1/sessions/:id` endpoint.

## Test plan

- [ ] PATCH with `{"cross_pollination": true}` works
- [ ] PATCH with `{"distribution": [{"channel": "telegram", "group_id": "-123"}]}` works

🤖 Generated with [Claude Code](https://claude.com/claude-code)