### PR TITLE
Add distribution/cross_pollination to PATCH sessions + fix quickstart link

### DIFF
--- a/src/app/(dashboard)/page.tsx
+++ b/src/app/(dashboard)/page.tsx
@@ -261,7 +261,7 @@ export default async function Dashboard({
               <p className="text-muted-foreground text-lg mb-4">No sessions yet, create one to get started.</p>
               <div className="flex justify-center gap-4">
                 <CreateSessionButton text="Get Started" />
-                <Link href="https://harmonica.chat/support" target="_blank">
+                <Link href="https://help.harmonica.chat/quickstart" target="_blank">
                   <Button variant="outline">
                     How it works
                   </Button>

--- a/src/app/api/v1/sessions/[id]/route.ts
+++ b/src/app/api/v1/sessions/[id]/route.ts
@@ -48,6 +48,8 @@ const ALLOWED_UPDATE_FIELDS: (keyof UpdateSessionRequest)[] = [
   'context',
   'critical',
   'prompt',
+  'cross_pollination',
+  'distribution',
 ];
 
 export async function PATCH(
@@ -76,6 +78,11 @@ export async function PATCH(
     // Keep prompt_summary in sync when prompt changes
     if (typeof update.prompt === 'string') {
       update.prompt_summary = update.prompt.substring(0, 500);
+    }
+
+    // Serialize distribution array to JSON string for storage
+    if (update.distribution !== undefined) {
+      update.distribution = update.distribution ? JSON.stringify(update.distribution) : null;
     }
 
     if (Object.keys(update).length === 0) {

--- a/src/lib/api-types.ts
+++ b/src/lib/api-types.ts
@@ -47,6 +47,8 @@ export interface UpdateSessionRequest {
   context?: string;
   critical?: string;
   prompt?: string;
+  cross_pollination?: boolean;
+  distribution?: DistributionTarget[];
 }
 
 export interface SessionCreated extends SessionListItem {


### PR DESCRIPTION
## Summary
- Add `distribution` and `cross_pollination` fields to PATCH `/api/v1/sessions/:id` endpoint (HAR-502)
- Update "How it works" link on empty dashboard from `harmonica.chat/support` to `help.harmonica.chat/quickstart`

## Test plan
- [ ] Verify PATCH endpoint accepts distribution and cross_pollination fields
- [ ] Verify "How it works" button links to docs quickstart page

🤖 Generated with [Claude Code](https://claude.com/claude-code)